### PR TITLE
Fix Docker invalid reference format by wrapping the volume path in qu…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 
 
 shell: 
-	docker run --rm -ti --env-file etc/env -p 8765:80 -p 8000:8000 -v ${ROOT_DIR}/src:/home/wmb/www/src ${IMAGE} bash
+	docker run --rm -ti --env-file etc/env -p 8765:80 -p 8000:8000 -v "${ROOT_DIR}/src:/home/wmb/www/src" ${IMAGE} bash
 
 run: 
-	docker run --rm -ti --env-file etc/env -p 8765:80 -p 8000:8000 -v ${ROOT_DIR}/src:/home/wmb/www/src ${IMAGE} /home/wmb/www/cmd_run.sh
+	docker run --rm -ti --env-file etc/env -p 8765:80 -p 8000:8000 -v "${ROOT_DIR}/src:/home/wmb/www/src" ${IMAGE} /home/wmb/www/cmd_run.sh


### PR DESCRIPTION
```markdown
### PR Title:
**Fix Docker invalid reference format by wrapping volume path in quotes**

### PR Description:
This PR addresses an issue where the `docker run` command in the Makefile was throwing an "invalid reference format" error due to the volume path not being properly quoted. The issue occurred when attempting to run:

```
docker run --rm -ti --env-file etc/env -p 8765:80 -p 8000:8000 -v /home/gt/outreachy/src:/home/wmb/www/src quickstatements3:dev bash
```

To resolve this, I wrapped the `${ROOT_DIR}` in quotes to ensure the path is correctly interpreted, preventing Docker from misinterpreting it:

```make
docker run --rm -ti --env-file etc/env -p 8765:80 -p 8000:8000 -v "${ROOT_DIR}/src:/home/wmb/www/src" ${IMAGE} bash
```

### Changes Made:
- Wrapped `${ROOT_DIR}/src` in quotes in the `shell` and `run` targets in the Makefile to ensure correct handling of file paths with special characters or double slashes.

### Testing:
- Successfully ran `make shell` and `make run` without encountering the "invalid reference format" error.

### Issue Resolved:
- Fixed the Docker invalid reference format error during container run.
```