### PR TITLE
Change button colors from green to blue using block css and provide screenshots

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1,4 +1,25 @@
 {% extends "layout.html" %}
+{% load static %}
+
+{% block css %}
+
+  /* custom-styles */
+
+  /* Override Pico CSS button styles */
+  a[role="button"],
+  input[type="submit"] {
+      background-color: blue !important;
+      /* Use !important to ensure it overrides existing styles */
+      color: white;
+      border-color: blue;
+  }
+
+  /* Optional: Change button hover and active states */
+  a[role="button"]:hover,
+  input[type="submit"]:hover {
+      background-color: darkblue !important;
+  }
+{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
### PR Title:
**Change button colors from green to blue using block css and provide screenshots**

### PR Description:
This PR addresses the Outreachy task to change the color of all buttons on the home page from green to blue. The change was made using the `{% block css %}` in `index.html` to scope the modification to the home page only.

### Steps Completed:
1. Took a screenshot of the original home page before the CSS changes and saved it as `screenshot1.jpg`.
2. Used the `{% block css %}` in `index.html` to modify the button background color from green to blue.
3. Took a screenshot of the updated home page after the CSS changes and saved it as `screenshot2.jpg`.

### Changes Made:
- Modified the CSS using `{% block css %}` in the `index.html` to override the button styles, changing their background color from green to blue.
- No additional CSS files were created, and the changes apply only to the home page.

### Screenshots:
- **Before CSS change (green buttons)**: `outreachy/screenshot1.jpg`
- **After CSS change (blue buttons)**: `outreachy/screenshot2.jpg`

### Testing:
- Verified that all buttons on the home page now display the correct blue color instead of green.
- Confirmed that the changes were scoped to the home page using the `{% block css %}` feature and did not affect other pages.
- Tested responsiveness to ensure the buttons are user-friendly across different devices and screen sizes.
